### PR TITLE
Improve fairness of goodluck benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 A suite of benchmarks designed to test and compare JavaScript ECS library performance across a variety of challenging circumstances.
 
-|             |         packed_1 |         packed_5 |     simple_iter |        frag_iter |      add_remove |
-| ----------- | ---------------: | ---------------: | --------------: | ---------------: | --------------: |
-| bitecs      | **155,690 op/s** |      24,031 op/s |     19,351 op/s | **256,273 op/s** |        969 op/s |
-| ecsy        |      13,228 op/s |       7,980 op/s |      4,049 op/s |      27,031 op/s |        779 op/s |
-| flock-ecs   |       3,674 op/s |       4,392 op/s |      2,169 op/s |       9,480 op/s |     17,791 op/s |
-| geotic      |      35,887 op/s |      40,176 op/s |     27,413 op/s |      52,031 op/s |        883 op/s |
-| goodluck    |     112,402 op/s | **115,208 op/s** |     45,434 op/s |     128,875 op/s | **91,454 op/s** |
-| makr        |      13,108 op/s |      10,912 op/s |      6,754 op/s |      22,589 op/s |     26,650 op/s |
-| perform-ecs |      61,016 op/s |      56,979 op/s | **74,168 op/s** |      29,918 op/s |        345 op/s |
-| tiny-ecs    |      17,686 op/s |      18,799 op/s |     28,911 op/s |      53,393 op/s |        829 op/s |
+|             |         packed_1 |        packed_5 |     simple_iter |        frag_iter |      add_remove |
+| ----------- | ---------------: | --------------: | --------------: | ---------------: | --------------: |
+| bitecs      | **156,884 op/s** |     23,825 op/s |     18,774 op/s | **254,007 op/s** |        950 op/s |
+| ecsy        |      13,942 op/s |      7,223 op/s |      3,463 op/s |      23,958 op/s |        752 op/s |
+| flock-ecs   |       3,269 op/s |      4,658 op/s |      1,900 op/s |       8,240 op/s |     18,702 op/s |
+| geotic      |      36,420 op/s |     46,334 op/s |     29,546 op/s |      53,521 op/s |        915 op/s |
+| goodluck    |      55,556 op/s |     54,153 op/s |     30,100 op/s |     111,126 op/s | **87,386 op/s** |
+| makr        |      13,207 op/s |     11,121 op/s |      6,910 op/s |      25,396 op/s |     27,215 op/s |
+| perform-ecs |      62,546 op/s | **59,691 op/s** | **73,185 op/s** |      29,505 op/s |        346 op/s |
+| tiny-ecs    |      18,145 op/s |     17,819 op/s |     30,253 op/s |      54,270 op/s |        916 op/s |
 
 The best result for each benchmark is marked in bold text. Note that run to run variance for these benchmarks is typically 1-4%. Any benchmarks within a few percent of each other should be considered “effectively equal”. The above benchmarks are run on node v15.8.0.
 

--- a/src/cases/goodluck/packed_1.js
+++ b/src/cases/goodluck/packed_1.js
@@ -14,38 +14,38 @@ const HAS_C = 1 << 2;
 const HAS_D = 1 << 3;
 const HAS_E = 1 << 4;
 
-function A(x = 0) {
+function A(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_A;
-    world.A[entity] = x;
+    world.A[entity] = { value };
   };
 }
 
-function B(x = 0) {
+function B(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_B;
-    world.B[entity] = x;
+    world.B[entity] = { value };
   };
 }
 
-function C(x = 0) {
+function C(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_C;
-    world.C[entity] = x;
+    world.C[entity] = { value };
   };
 }
 
-function D(x = 0) {
+function D(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_D;
-    world.D[entity] = x;
+    world.D[entity] = { value };
   };
 }
 
-function E(x = 0) {
+function E(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_E;
-    world.E[entity] = x;
+    world.E[entity] = { value };
   };
 }
 
@@ -59,7 +59,7 @@ export default (count) => {
   return () => {
     for (let i = 0; i < world.Signature.length; i++) {
       if ((world.Signature[i] & HAS_A) === HAS_A) {
-        world.A[i] *= 2;
+        world.A[i].value *= 2;
       }
     }
   };

--- a/src/cases/goodluck/packed_5.js
+++ b/src/cases/goodluck/packed_5.js
@@ -14,38 +14,38 @@ const HAS_C = 1 << 2;
 const HAS_D = 1 << 3;
 const HAS_E = 1 << 4;
 
-function A(x = 0) {
+function A(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_A;
-    world.A[entity] = x;
+    world.A[entity] = { value };
   };
 }
 
-function B(x = 0) {
+function B(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_B;
-    world.B[entity] = x;
+    world.B[entity] = { value };
   };
 }
 
-function C(x = 0) {
+function C(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_C;
-    world.C[entity] = x;
+    world.C[entity] = { value };
   };
 }
 
-function D(x = 0) {
+function D(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_D;
-    world.D[entity] = x;
+    world.D[entity] = { value };
   };
 }
 
-function E(x = 0) {
+function E(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_E;
-    world.E[entity] = x;
+    world.E[entity] = { value };
   };
 }
 
@@ -59,31 +59,31 @@ export default (count) => {
   return () => {
     for (let i = 0; i < world.Signature.length; i++) {
       if ((world.Signature[i] & HAS_A) === HAS_A) {
-        world.A[i] *= 2;
+        world.A[i].value *= 2;
       }
     }
 
     for (let i = 0; i < world.Signature.length; i++) {
       if ((world.Signature[i] & HAS_B) === HAS_B) {
-        world.B[i] *= 2;
+        world.B[i].value *= 2;
       }
     }
 
     for (let i = 0; i < world.Signature.length; i++) {
       if ((world.Signature[i] & HAS_C) === HAS_C) {
-        world.C[i] *= 2;
+        world.C[i].value *= 2;
       }
     }
 
     for (let i = 0; i < world.Signature.length; i++) {
       if ((world.Signature[i] & HAS_D) === HAS_D) {
-        world.D[i] *= 2;
+        world.D[i].value *= 2;
       }
     }
 
     for (let i = 0; i < world.Signature.length; i++) {
       if ((world.Signature[i] & HAS_E) === HAS_E) {
-        world.E[i] *= 2;
+        world.E[i].value *= 2;
       }
     }
   };

--- a/src/cases/goodluck/simple_iter.js
+++ b/src/cases/goodluck/simple_iter.js
@@ -14,38 +14,38 @@ const HAS_C = 1 << 2;
 const HAS_D = 1 << 3;
 const HAS_E = 1 << 4;
 
-function A(x = 0) {
+function A(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_A;
-    world.A[entity] = x;
+    world.A[entity] = { value };
   };
 }
 
-function B(x = 0) {
+function B(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_B;
-    world.B[entity] = x;
+    world.B[entity] = { value };
   };
 }
 
-function C(x = 0) {
+function C(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_C;
-    world.C[entity] = x;
+    world.C[entity] = { value };
   };
 }
 
-function D(x = 0) {
+function D(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_D;
-    world.D[entity] = x;
+    world.D[entity] = { value };
   };
 }
 
-function E(x = 0) {
+function E(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_E;
-    world.E[entity] = x;
+    world.E[entity] = { value };
   };
 }
 
@@ -66,25 +66,25 @@ export default (count) => {
   return () => {
     for (let i = 0; i < world.Signature.length; i++) {
       if ((world.Signature[i] & QUERY_AB) === QUERY_AB) {
-        let x = world.A[i];
-        world.A[i] = world.B[i];
-        world.B[i] = x;
+        let x = world.A[i].value;
+        world.A[i].value = world.B[i].value;
+        world.B[i].value = x;
       }
     }
 
     for (let i = 0; i < world.Signature.length; i++) {
       if ((world.Signature[i] & QUERY_CD) === QUERY_CD) {
-        let x = world.C[i];
-        world.C[i] = world.D[i];
-        world.D[i] = x;
+        let x = world.C[i].value;
+        world.C[i].value = world.D[i].value;
+        world.D[i].value = x;
       }
     }
 
     for (let i = 0; i < world.Signature.length; i++) {
       if ((world.Signature[i] & QUERY_CE) === QUERY_CE) {
-        let x = world.C[i];
-        world.C[i] = world.E[i];
-        world.E[i] = x;
+        let x = world.C[i].value;
+        world.C[i].value = world.E[i].value;
+        world.E[i].value = x;
       }
     }
   };


### PR DESCRIPTION
Goodluck's cases were using integers instead of _box_ objects. Doing so was artificially buffing the performances.
cc @stasm 