### PR TITLE
Add entity_cycle benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ A suite of benchmarks designed to test and compare JavaScript ECS library perfor
 
 |             |     packed_1 |     packed_5 |  simple_iter |    frag_iter | entity_cycle |  add_remove |
 | ----------- | -----------: | -----------: | -----------: | -----------: | -----------: | ----------: |
-| bitecs      | 351,356 op/s | 332,906 op/s | 196,004 op/s | 642,282 op/s |   6,181 op/s |  1,525 op/s |
-| ecsy        |  13,942 op/s |   7,223 op/s |   3,463 op/s |  23,958 op/s |   1,440 op/s |    752 op/s |
-| flock-ecs   |   3,269 op/s |   4,658 op/s |   1,900 op/s |   8,240 op/s |     169 op/s | 18,702 op/s |
-| geotic      |  36,420 op/s |  46,334 op/s |  29,546 op/s |  53,521 op/s |   1,356 op/s |    915 op/s |
-| goodluck    |  55,556 op/s |  54,153 op/s |  30,100 op/s | 111,126 op/s | 119,464 op/s | 87,386 op/s |
-| makr        |  13,207 op/s |  11,121 op/s |   6,910 op/s |  25,396 op/s |  94,902 op/s | 27,215 op/s |
-| perform-ecs |  62,546 op/s |  59,691 op/s |  73,185 op/s |  29,505 op/s |   2,186 op/s |    346 op/s |
-| picoes      |   3,799 op/s |   2,739 op/s |   1,935 op/s |   5,456 op/s |   9,253 op/s |  2,602 op/s |
-| tiny-ecs    |  18,145 op/s |  17,819 op/s |  30,253 op/s |  54,270 op/s |   2,311 op/s |    916 op/s |
+| bitecs      | 328,625 op/s | 328,672 op/s | 191,774 op/s | 659,881 op/s |     623 op/s |  1,510 op/s |
+| ecsy        |  13,810 op/s |   7,343 op/s |   4,707 op/s |  25,882 op/s |      32 op/s |    788 op/s |
+| flock-ecs   |   3,599 op/s |   4,722 op/s |   1,610 op/s |   7,925 op/s |      88 op/s | 18,523 op/s |
+| geotic      |  32,987 op/s |  47,799 op/s |  27,691 op/s |  49,348 op/s |      29 op/s |    888 op/s |
+| goodluck    |  51,657 op/s |  52,887 op/s |  29,363 op/s | 110,981 op/s |  12,959 op/s | 81,781 op/s |
+| makr        |  12,707 op/s |  10,368 op/s |   6,653 op/s |  24,439 op/s |   8,790 op/s | 25,504 op/s |
+| perform-ecs |  55,518 op/s |  57,716 op/s |  72,009 op/s |  28,827 op/s |      38 op/s |    350 op/s |
+| picoes      |   3,827 op/s |   2,729 op/s |   1,897 op/s |   5,522 op/s |   1,050 op/s |  2,997 op/s |
+| tiny-ecs    |  19,419 op/s |  19,013 op/s |  29,778 op/s |  11,676 op/s |      38 op/s |    895 op/s |
 
 The best result for each benchmark is marked in bold text. Note that run to run variance for these benchmarks is typically 1-4%. Any benchmarks within a few percent of each other should be considered “effectively equal”. The above benchmarks are run on node v15.8.0.
 
@@ -74,7 +74,7 @@ This benchmark is designed to test how the ECS handles iteration through a fragm
 
 This benchmark is designed to test the base cost of constructing and destroying entities into the ECS.
 
-- **Dataset:** 100 entities with a single `A` component.
+- **Dataset:** 1,000 entities with a single `A` component.
 - **Test:** Iterate through all entities, and create 2 entities with a `B` component. Then iterate through all entities with a `B` component and destroy them.
 
 ### Add / Remove

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 A suite of benchmarks designed to test and compare JavaScript ECS library performance across a variety of challenging circumstances.
 
-|             |     packed_1 |     packed_5 |  simple_iter |    frag_iter |  add_remove |
-| ----------- | -----------: | -----------: | -----------: | -----------: | ----------: |
-| bitecs      | 351,356 op/s | 332,906 op/s | 196,004 op/s | 642,282 op/s |  1,525 op/s |
-| ecsy        |  13,942 op/s |   7,223 op/s |   3,463 op/s |  23,958 op/s |    752 op/s |
-| flock-ecs   |   3,269 op/s |   4,658 op/s |   1,900 op/s |   8,240 op/s | 18,702 op/s |
-| geotic      |  36,420 op/s |  46,334 op/s |  29,546 op/s |  53,521 op/s |    915 op/s |
-| goodluck    |  55,556 op/s |  54,153 op/s |  30,100 op/s | 111,126 op/s | 87,386 op/s |
-| makr        |  13,207 op/s |  11,121 op/s |   6,910 op/s |  25,396 op/s | 27,215 op/s |
-| perform-ecs |  62,546 op/s |  59,691 op/s |  73,185 op/s |  29,505 op/s |    346 op/s |
-| picoes      |   3,799 op/s |   2,739 op/s |   1,935 op/s |   5,456 op/s |  2,602 op/s |
-| tiny-ecs    |  18,145 op/s |  17,819 op/s |  30,253 op/s |  54,270 op/s |    916 op/s |
+|             |     packed_1 |     packed_5 |  simple_iter |    frag_iter | entity_cycle |  add_remove |
+| ----------- | -----------: | -----------: | -----------: | -----------: | -----------: | ----------: |
+| bitecs      | 351,356 op/s | 332,906 op/s | 196,004 op/s | 642,282 op/s |   6,181 op/s |  1,525 op/s |
+| ecsy        |  13,942 op/s |   7,223 op/s |   3,463 op/s |  23,958 op/s |   1,440 op/s |    752 op/s |
+| flock-ecs   |   3,269 op/s |   4,658 op/s |   1,900 op/s |   8,240 op/s |     169 op/s | 18,702 op/s |
+| geotic      |  36,420 op/s |  46,334 op/s |  29,546 op/s |  53,521 op/s |   1,356 op/s |    915 op/s |
+| goodluck    |  55,556 op/s |  54,153 op/s |  30,100 op/s | 111,126 op/s | 119,464 op/s | 87,386 op/s |
+| makr        |  13,207 op/s |  11,121 op/s |   6,910 op/s |  25,396 op/s |  94,902 op/s | 27,215 op/s |
+| perform-ecs |  62,546 op/s |  59,691 op/s |  73,185 op/s |  29,505 op/s |   2,186 op/s |    346 op/s |
+| picoes      |   3,799 op/s |   2,739 op/s |   1,935 op/s |   5,456 op/s |   9,253 op/s |  2,602 op/s |
+| tiny-ecs    |  18,145 op/s |  17,819 op/s |  30,253 op/s |  54,270 op/s |   2,311 op/s |    916 op/s |
 
 The best result for each benchmark is marked in bold text. Note that run to run variance for these benchmarks is typically 1-4%. Any benchmarks within a few percent of each other should be considered “effectively equal”. The above benchmarks are run on node v15.8.0.
 
@@ -69,6 +69,13 @@ This benchmark is designed to test how the ECS handles iteration through a fragm
 
 - **Dataset:** 26 component types (`A` through `Z`), each with 100 entities plus a `Data` component.
 - **Test:** Iterate through all entities with a `Data` component and double its value.
+
+### Entity Cycle
+
+This benchmark is designed to test the base cost of constructing and destroying entities into the ECS.
+
+- **Dataset:** 100 entities with a single `A` component.
+- **Test:** Iterate through all entities, and create 2 entities with a `B` component. Then iterate through all entities with a `B` component and destroy them.
 
 ### Add / Remove
 

--- a/src/bench.js
+++ b/src/bench.js
@@ -19,7 +19,7 @@ const BENCHMARKS = {
   packed_5: 1_000,
   simple_iter: 1_000,
   frag_iter: 100,
-  entity_cycle: 100,
+  entity_cycle: 1_000,
   add_remove: 1_000,
 };
 

--- a/src/bench.js
+++ b/src/bench.js
@@ -19,6 +19,7 @@ const BENCHMARKS = {
   packed_5: 1_000,
   simple_iter: 1_000,
   frag_iter: 100,
+  entity_cycle: 100,
   add_remove: 1_000,
 };
 

--- a/src/bench_worker.js
+++ b/src/bench_worker.js
@@ -15,13 +15,17 @@ try {
 let setup = mod.default;
 let fn = setup(workerData.config);
 
-// Run an initial cycle to get an estimate
-let initial_n = 1_000;
-let initial_ms = bench_iter(fn, initial_n) / initial_n;
+let cycle_n = 1;
+let cycle_ms = 0;
+let cycle_total_ms = 0;
 
-// Try to correct the estimate for 500ms
-let cycle_n = 500 / initial_ms;
-let cycle_ms = bench_iter(fn, cycle_n) / cycle_n;
+// Run multiple cycles to get an estimate
+while (cycle_total_ms < 500) {
+  let elapsed = bench_iter(fn, cycle_n);
+  cycle_ms = elapsed / cycle_n;
+  cycle_n *= 2;
+  cycle_total_ms += elapsed;
+}
 
 // Try to estimate the iteration count for 500ms
 let target_n = 500 / cycle_ms;

--- a/src/cases/bitecs/entity_cycle.js
+++ b/src/cases/bitecs/entity_cycle.js
@@ -1,0 +1,38 @@
+import bitECS from "bitecs";
+
+export default (count) => {
+  let world = bitECS({ maxEntities: count * 4 });
+
+  let a = world.registerComponent("A", { value: "int32" });
+  let b = world.registerComponent("B", { value: "int32" });
+
+  world.registerSystem({
+    name: "SPAWN_B",
+    components: ["A"],
+    update: (entities) => {
+      for (let i = 0; i < entities.length; i++) {
+        let value = a.value[entities[i]];
+        world.addComponent("B", world.addEntity(), { value });
+        world.addComponent("B", world.addEntity(), { value });
+      }
+    },
+  });
+
+  world.registerSystem({
+    name: "KILL_B",
+    components: ["B"],
+    update: (entities) => {
+      for (let i = 0; i < entities.length; i++) {
+        world.removeEntity(entities[i]);
+      }
+    },
+  });
+
+  for (let i = 0; i < count; i++) {
+    world.addComponent("A", world.addEntity(), { value: i });
+  }
+
+  return () => {
+    world.step();
+  };
+};

--- a/src/cases/ecsy/entity_cycle.js
+++ b/src/cases/ecsy/entity_cycle.js
@@ -1,0 +1,57 @@
+import { Component, System, Types, World } from "ecsy";
+
+class A extends Component {
+  static schema = {
+    value: { type: Types.Number },
+  };
+}
+
+class B extends Component {
+  static schema = {
+    value: { type: Types.Number },
+  };
+}
+
+class SpawnB extends System {
+  static queries = {
+    entities: { components: [A] },
+  };
+
+  execute() {
+    this.queries.entities.results.forEach((entity) => {
+      let value = entity.getComponent(A).value;
+      this.world.createEntity().addComponent(B, { value });
+      this.world.createEntity().addComponent(B, { value });
+    });
+  }
+}
+
+class KillB extends System {
+  static queries = {
+    entities: { components: [B] },
+  };
+
+  execute() {
+    this.queries.entities.results.forEach((entity) => {
+      entity.remove();
+    });
+  }
+}
+
+export default (count) => {
+  let world = new World();
+
+  world
+    .registerComponent(A)
+    .registerComponent(B)
+    .registerSystem(SpawnB)
+    .registerSystem(KillB);
+
+  for (let i = 0; i < count; i++) {
+    world.createEntity().addComponent(A, { value: i });
+  }
+
+  return () => {
+    world.execute();
+  };
+};

--- a/src/cases/flock-ecs/entity_cycle.js
+++ b/src/cases/flock-ecs/entity_cycle.js
@@ -1,0 +1,34 @@
+import flock from "flock-ecs";
+
+const A = new flock.Component(() => ({ value: 0 }));
+const B = new flock.Component(() => ({ value: 0 }));
+
+const WITH_A = [new flock.Current(A)];
+const WITH_B = [new flock.Current(B)];
+
+export default (count) => {
+  let world = new flock.World();
+
+  world.registerComponent(A);
+  world.registerComponent(B);
+
+  for (let i = 0; i < count; i++) {
+    world.createEntity().addComponent(A, { value: i });
+  }
+
+  world.maintain();
+
+  return () => {
+    for (let entity of world.query(WITH_A)) {
+      let value = entity.getComponent(A).value;
+      world.createEntity().addComponent(B, { value });
+      world.createEntity().addComponent(B, { value });
+    }
+
+    for (let entity of world.query(WITH_B)) {
+      entity.remove();
+    }
+
+    world.maintain();
+  };
+};

--- a/src/cases/geotic/entity_cycle.js
+++ b/src/cases/geotic/entity_cycle.js
@@ -1,0 +1,32 @@
+import { Component, Engine } from "geotic";
+
+class A extends Component {}
+class B extends Component {}
+
+export default (count) => {
+  const engine = new Engine();
+
+  engine.registerComponent(A);
+  engine.registerComponent(B);
+
+  const world = engine.createWorld();
+
+  for (let i = 0; i < count; i++) {
+    world.createEntity().add(A, { value: i });
+  }
+
+  let with_a = world.createQuery({ all: [A] });
+  let with_b = world.createQuery({ all: [B] });
+
+  return () => {
+    for (let entity of with_a.get()) {
+      let value = entity.a.value;
+      world.createEntity().add(B, { value });
+      world.createEntity().add(B, { value });
+    }
+
+    for (let entity of with_b.get()) {
+      entity.destroy();
+    }
+  };
+};

--- a/src/cases/goodluck/entity_cycle.js
+++ b/src/cases/goodluck/entity_cycle.js
@@ -1,0 +1,47 @@
+import { BaseWorld, destroyEntity, instantiate } from "goodluck";
+
+class World extends BaseWorld {
+  A = [];
+  B = [];
+}
+
+const HAS_A = 1 << 0;
+const HAS_B = 1 << 1;
+
+function A(value) {
+  return (world, entity) => {
+    world.Signature[entity] |= HAS_A;
+    world.A[entity] = { value };
+  };
+}
+
+function B(value) {
+  return (world, entity) => {
+    world.Signature[entity] |= HAS_B;
+    world.B[entity] = { value };
+  };
+}
+
+export default (count) => {
+  let world = new World();
+
+  for (let i = 0; i < count; i++) {
+    instantiate(world, { Using: [A(i)] });
+  }
+
+  return () => {
+    for (let i = 0; i < world.Signature.length; i++) {
+      if ((world.Signature[i] & HAS_A) === HAS_A) {
+        let value = world.A[i].value;
+        instantiate(world, { Using: [B(value)] });
+        instantiate(world, { Using: [B(value)] });
+      }
+    }
+
+    for (let i = 0; i < world.Signature.length; i++) {
+      if ((world.Signature[i] & HAS_B) === HAS_B) {
+        destroyEntity(world, i);
+      }
+    }
+  };
+};

--- a/src/cases/makr/entity_cycle.js
+++ b/src/cases/makr/entity_cycle.js
@@ -1,0 +1,29 @@
+import makr from "makr";
+
+function A(value) {
+  this.value = value;
+}
+
+function B(value) {
+  this.value = value;
+}
+
+export default (count) => {
+  let em = makr(A, B);
+
+  for (let i = 0; i < count; i++) {
+    em.create().add(new A(i));
+  }
+
+  return () => {
+    for (let entity of em.query(A)) {
+      let a = entity.get(A);
+      em.create().add(new B(a.value));
+      em.create().add(new B(a.value));
+    }
+
+    for (let entity of em.query(B)) {
+      entity.destroy();
+    }
+  };
+};

--- a/src/cases/perform-ecs/entity_cycle.js
+++ b/src/cases/perform-ecs/entity_cycle.js
@@ -1,0 +1,62 @@
+import {
+  Component,
+  ECS,
+  EntityViewFactory,
+  makeComponent,
+  System,
+} from "perform-ecs";
+
+class A extends Component {
+  reset(obj, a) {
+    obj.a = a;
+  }
+}
+
+class B extends Component {
+  reset(obj, b) {
+    obj.b = b;
+  }
+}
+
+makeComponent(A);
+makeComponent(B);
+
+class SpawnB extends System {
+  view = EntityViewFactory.createView({
+    components: [A],
+  });
+
+  update() {
+    for (let entity of this.view.entities) {
+      this.ecs.createEntity([{ component: B, args: [entity.a] }]);
+      this.ecs.createEntity([{ component: B, args: [entity.a] }]);
+    }
+  }
+}
+
+class KillB extends System {
+  view = EntityViewFactory.createView({
+    components: [B],
+  });
+
+  update() {
+    for (let entity of this.view.entities) {
+      this.ecs.removeEntity(entity);
+    }
+  }
+}
+
+export default (count) => {
+  let ecs = new ECS();
+
+  ecs.registerSystem(new SpawnB());
+  ecs.registerSystem(new KillB());
+
+  for (let i = 0; i < count; i++) {
+    ecs.createEntity([{ component: A, args: [i] }]);
+  }
+
+  return () => {
+    ecs.update(0);
+  };
+};

--- a/src/cases/picoes/entity_cycle.js
+++ b/src/cases/picoes/entity_cycle.js
@@ -1,0 +1,27 @@
+import { World } from "picoes";
+
+function Box(value = 0) {
+  this.value = value;
+}
+
+export default (count) => {
+  let world = new World();
+
+  world.component("a", Box);
+  world.component("b", Box);
+
+  for (let i = 0; i < count; i++) {
+    world.entity().set("a", i);
+  }
+
+  return () => {
+    world.each("a", (a) => {
+      world.entity().set("b", a.value);
+      world.entity().set("b", a.value);
+    });
+
+    world.each("b", (_, entity) => {
+      entity.destroy();
+    });
+  };
+};

--- a/src/cases/tiny-ecs/entity_cycle.js
+++ b/src/cases/tiny-ecs/entity_cycle.js
@@ -1,0 +1,31 @@
+import pkg from "tiny-ecs";
+
+const { EntityManager } = pkg;
+
+function A(value) {
+  this.value = value;
+}
+
+function B(value) {
+  this.value = value;
+}
+
+export default (count) => {
+  let ecs = new EntityManager();
+
+  for (let i = 0; i < count; i++) {
+    ecs.createEntity().addComponent(A);
+  }
+
+  return () => {
+    for (let entity of ecs.queryComponents([A])) {
+      let value = entity.a.value;
+      ecs.createEntity().addComponent(B).value = value;
+      ecs.createEntity().addComponent(B).value = value;
+    }
+
+    for (let entity of ecs.queryComponents([B])) {
+      entity.remove();
+    }
+  };
+};


### PR DESCRIPTION
~Initially I wanted to cycle 1,000 entities. I had to lower the count to 100 because neither `ecsy` nor `flock-ecs` can do it in a reasonable time.~