### PR TITLE
PicoES 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 A suite of benchmarks designed to test and compare JavaScript ECS library performance across a variety of challenging circumstances.
 
-|             |     packed_1 |     packed_5 |  simple_iter |    frag_iter | entity_cycle |  add_remove |
-| ----------- | -----------: | -----------: | -----------: | -----------: | -----------: | ----------: |
-| bitecs      | 348,080 op/s | 313,344 op/s | 194,103 op/s | 668,794 op/s |   3,322 op/s |  6,309 op/s |
-| ecsy        |  11,324 op/s |   6,218 op/s |   4,566 op/s |  23,978 op/s |      28 op/s |    705 op/s |
-| flock-ecs   |   3,584 op/s |   4,531 op/s |   1,588 op/s |   7,452 op/s |      88 op/s | 19,139 op/s |
-| geotic      |  40,668 op/s |  46,973 op/s |  27,485 op/s |  47,237 op/s |      30 op/s |    853 op/s |
-| goodluck    |  52,052 op/s |  52,954 op/s |  29,037 op/s | 111,839 op/s |  13,884 op/s | 89,526 op/s |
-| javelin-ecs |  78,667 op/s |  55,237 op/s |  41,673 op/s | 124,992 op/s |     330 op/s |  3,441 op/s |
-| makr        |  13,483 op/s |  11,180 op/s |   6,900 op/s |  26,212 op/s |  10,364 op/s | 27,469 op/s |
-| perform-ecs |  57,223 op/s |  58,849 op/s |  75,751 op/s |  29,045 op/s |      38 op/s |    324 op/s |
-| picoes      |   3,835 op/s |   2,704 op/s |   1,893 op/s |   5,477 op/s |   1,038 op/s |  2,650 op/s |
-| tiny-ecs    |  19,493 op/s |  18,211 op/s |  28,154 op/s |  49,216 op/s |      39 op/s |    854 op/s |
+|             |     packed_1 |     packed_5 |  simple_iter |    frag_iter | entity_cycle |   add_remove |
+| ----------- | -----------: | -----------: | -----------: | -----------: | -----------: | -----------: |
+| bitecs      | 398,843 op/s | 384,813 op/s | 221,454 op/s | 791,205 op/s |   4,407 op/s |   8,491 op/s |
+| ecsy        |  18,935 op/s |   9,042 op/s |   6,105 op/s |  32,452 op/s |      42 op/s |     864 op/s |
+| flock-ecs   |   5,036 op/s |   6,130 op/s |   2,283 op/s |  12,780 op/s |      95 op/s |  28,341 op/s |
+| geotic      |  52,929 op/s |  74,522 op/s |  46,648 op/s |  71,527 op/s |      38 op/s |   1,043 op/s |
+| goodluck    |  78,407 op/s |  77,178 op/s |  36,055 op/s | 159,210 op/s |  17,637 op/s | 116,252 op/s |
+| javelin-ecs | 101,249 op/s |  94,856 op/s |  74,556 op/s | 167,545 op/s |     375 op/s |   3,318 op/s |
+| makr        |  17,636 op/s |  14,125 op/s |   9,427 op/s |  35,799 op/s |  13,237 op/s |  30,274 op/s |
+| perform-ecs |  95,183 op/s |  94,492 op/s | 119,659 op/s |  40,631 op/s |      55 op/s |     460 op/s |
+| picoes      |  31,345 op/s |   9,557 op/s |   5,778 op/s |  17,167 op/s |   1,596 op/s |   5,011 op/s |
+| tiny-ecs    |  27,960 op/s |  26,597 op/s |  38,677 op/s |  68,370 op/s |      56 op/s |   1,092 op/s |
 
 The best result for each benchmark is marked in bold text. Note that run to run variance for these benchmarks is typically 1-4%. Any benchmarks within a few percent of each other should be considered “effectively equal”. The above benchmarks are run on node v15.12.0.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "goodluck": "^5.2.0",
         "makr": "^2.1.1",
         "perform-ecs": "^0.7.8",
-        "picoes": "^1.0.0-alpha4",
+        "picoes": "^1.0.0",
         "tiny-ecs": "^2.0.0"
       },
       "devDependencies": {
@@ -90,9 +90,10 @@
       "integrity": "sha512-+4WYfCW6/ZVYQDF+78RJc7oWmK2dqtfsdDRfB/kyiHfbQfRIWldJqn2hpQt0ByDWQgtFQrMGGpED1S9wQj3WOw=="
     },
     "node_modules/picoes": {
-      "version": "1.0.0-alpha4",
-      "resolved": "https://registry.npmjs.org/picoes/-/picoes-1.0.0-alpha4.tgz",
-      "integrity": "sha512-CjmJ79XgfLpZAu+8LzxAWplwmVs1waUlbEo1CsJ03908G/B37ry6PdHMXwqghXXkxUxnNyglgxbSnBjm2cISbQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picoes/-/picoes-1.0.0.tgz",
+      "integrity": "sha512-M930o/vy0zAF55nFjUa8e7ZrU/WTB7jJjQKk2jImMyUkZVHStseUAPXo7STKs+wnzWXGkmUYZjN3qQZXb0+TDg==",
+      "license": "MIT"
     },
     "node_modules/tiny-ecs": {
       "version": "2.0.0",
@@ -170,9 +171,9 @@
       "integrity": "sha512-+4WYfCW6/ZVYQDF+78RJc7oWmK2dqtfsdDRfB/kyiHfbQfRIWldJqn2hpQt0ByDWQgtFQrMGGpED1S9wQj3WOw=="
     },
     "picoes": {
-      "version": "1.0.0-alpha4",
-      "resolved": "https://registry.npmjs.org/picoes/-/picoes-1.0.0-alpha4.tgz",
-      "integrity": "sha512-CjmJ79XgfLpZAu+8LzxAWplwmVs1waUlbEo1CsJ03908G/B37ry6PdHMXwqghXXkxUxnNyglgxbSnBjm2cISbQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picoes/-/picoes-1.0.0.tgz",
+      "integrity": "sha512-M930o/vy0zAF55nFjUa8e7ZrU/WTB7jJjQKk2jImMyUkZVHStseUAPXo7STKs+wnzWXGkmUYZjN3qQZXb0+TDg=="
     },
     "tiny-ecs": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "goodluck": "^5.2.0",
     "makr": "^2.1.1",
     "perform-ecs": "^0.7.8",
-    "picoes": "^1.0.0-alpha4",
+    "picoes": "^1.0.0",
     "tiny-ecs": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade PicoES to 1.0.0 stable version. Lots of performance improvements since then. You may need to re-run the benchmarks on your machine if you want to keep the numbers consistent from before. There were no interface changes in 1.0.0 that broke these benchmarks (although there were many breaking interface changes in general).