### PR TITLE
(goodluck) Store component data as class instances

### DIFF
--- a/src/cases/goodluck/add_remove.js
+++ b/src/cases/goodluck/add_remove.js
@@ -8,10 +8,22 @@ class World extends WorldImpl {
 const HAS_A = 1 << 0;
 const HAS_B = 1 << 1;
 
-function A(value = 0) {
+class A {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class B {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+function a(value = 0) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_A;
-    world.A[entity] = { value };
+    world.A[entity] = new A(value);
   };
 }
 
@@ -19,14 +31,14 @@ export default (count) => {
   let world = new World();
 
   for (let i = 0; i < count; i++) {
-    instantiate(world, [A(0)]);
+    instantiate(world, [a(0)]);
   }
 
   return () => {
     for (let i = 0; i < world.Signature.length; i++) {
       if ((world.Signature[i] & HAS_B) === 0) {
         world.Signature[i] |= HAS_B;
-        world.B[i] = { value: 0 };
+        world.B[i] = new B(0);
       }
     }
 

--- a/src/cases/goodluck/entity_cycle.js
+++ b/src/cases/goodluck/entity_cycle.js
@@ -8,17 +8,29 @@ class World extends WorldImpl {
 const HAS_A = 1 << 0;
 const HAS_B = 1 << 1;
 
-function A(value) {
+class A {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class B {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+function a(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_A;
-    world.A[entity] = { value };
+    world.A[entity] = new A(value);
   };
 }
 
-function B(value) {
+function b(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_B;
-    world.B[entity] = { value };
+    world.B[entity] = new B(value);
   };
 }
 
@@ -26,15 +38,15 @@ export default (count) => {
   let world = new World();
 
   for (let i = 0; i < count; i++) {
-    instantiate(world, [A(i)]);
+    instantiate(world, [a(i)]);
   }
 
   return () => {
     for (let i = 0; i < world.Signature.length; i++) {
       if ((world.Signature[i] & HAS_A) === HAS_A) {
         let value = world.A[i].value;
-        instantiate(world, [B(value)]);
-        instantiate(world, [B(value)]);
+        instantiate(world, [b(value)]);
+        instantiate(world, [b(value)]);
       }
     }
 

--- a/src/cases/goodluck/frag_iter.js
+++ b/src/cases/goodluck/frag_iter.js
@@ -30,20 +30,31 @@ class World extends WorldImpl {
   Data = [];
 }
 
-const COMPS = Array.from(
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
-  (name, index) => (value) => (world, entity) => {
-    world.Signature[entity] |= 1 << index;
-    world[name][entity] = { value };
+const COMPS = Array.from("ABCDEFGHIJKLMNOPQRSTUVWXYZ", (name, index) => {
+  class Comp {
+    constructor(value) {
+      this.value = value;
+    }
   }
-);
+
+  return (value) => (world, entity) => {
+    world.Signature[entity] |= 1 << index;
+    world[name][entity] = new Comp(value);
+  };
+});
 
 const HAS_DATA = 1 << 26;
 
-function Data(value) {
+class Data {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+function data(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_DATA;
-    world.Data[entity] = { value };
+    world.Data[entity] = new Data(value);
   };
 }
 
@@ -51,8 +62,8 @@ export default (count) => {
   let world = new World();
 
   for (let i = 0; i < count; i++) {
-    for (let Comp of COMPS) {
-      instantiate(world, [Data(0), Comp(0)]);
+    for (let comp of COMPS) {
+      instantiate(world, [data(0), comp(0)]);
     }
   }
 

--- a/src/cases/goodluck/packed_1.js
+++ b/src/cases/goodluck/packed_1.js
@@ -14,38 +14,68 @@ const HAS_C = 1 << 2;
 const HAS_D = 1 << 3;
 const HAS_E = 1 << 4;
 
-function A(value) {
+class A {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class B {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class C {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class D {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class E {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+function a(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_A;
-    world.A[entity] = { value };
+    world.A[entity] = new A(value);
   };
 }
 
-function B(value) {
+function b(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_B;
-    world.B[entity] = { value };
+    world.B[entity] = new B(value);
   };
 }
 
-function C(value) {
+function c(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_C;
-    world.C[entity] = { value };
+    world.C[entity] = new C(value);
   };
 }
 
-function D(value) {
+function d(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_D;
-    world.D[entity] = { value };
+    world.D[entity] = new D(value);
   };
 }
 
-function E(value) {
+function e(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_E;
-    world.E[entity] = { value };
+    world.E[entity] = new E(value);
   };
 }
 
@@ -53,7 +83,7 @@ export default (count) => {
   let world = new World();
 
   for (let i = 0; i < count; i++) {
-    instantiate(world, [A(0), B(0), C(0), D(0), E(0)]);
+    instantiate(world, [a(0), b(0), c(0), d(0), e(0)]);
   }
 
   return () => {

--- a/src/cases/goodluck/packed_5.js
+++ b/src/cases/goodluck/packed_5.js
@@ -14,38 +14,68 @@ const HAS_C = 1 << 2;
 const HAS_D = 1 << 3;
 const HAS_E = 1 << 4;
 
-function A(value) {
+class A {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class B {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class C {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class D {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class E {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+function a(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_A;
-    world.A[entity] = { value };
+    world.A[entity] = new A(value);
   };
 }
 
-function B(value) {
+function b(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_B;
-    world.B[entity] = { value };
+    world.B[entity] = new B(value);
   };
 }
 
-function C(value) {
+function c(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_C;
-    world.C[entity] = { value };
+    world.C[entity] = new C(value);
   };
 }
 
-function D(value) {
+function d(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_D;
-    world.D[entity] = { value };
+    world.D[entity] = new D(value);
   };
 }
 
-function E(value) {
+function e(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_E;
-    world.E[entity] = { value };
+    world.E[entity] = new E(value);
   };
 }
 
@@ -53,7 +83,7 @@ export default (count) => {
   let world = new World();
 
   for (let i = 0; i < count; i++) {
-    instantiate(world, [A(0), B(0), C(0), D(0), E(0)]);
+    instantiate(world, [a(0), b(0), c(0), d(0), e(0)]);
   }
 
   return () => {

--- a/src/cases/goodluck/simple_iter.js
+++ b/src/cases/goodluck/simple_iter.js
@@ -14,38 +14,68 @@ const HAS_C = 1 << 2;
 const HAS_D = 1 << 3;
 const HAS_E = 1 << 4;
 
-function A(value) {
+class A {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class B {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class C {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class D {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+class E {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+function a(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_A;
-    world.A[entity] = { value };
+    world.A[entity] = new A(value);
   };
 }
 
-function B(value) {
+function b(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_B;
-    world.B[entity] = { value };
+    world.B[entity] = new B(value);
   };
 }
 
-function C(value) {
+function c(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_C;
-    world.C[entity] = { value };
+    world.C[entity] = new C(value);
   };
 }
 
-function D(value) {
+function d(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_D;
-    world.D[entity] = { value };
+    world.D[entity] = new D(value);
   };
 }
 
-function E(value) {
+function e(value) {
   return (world, entity) => {
     world.Signature[entity] |= HAS_E;
-    world.E[entity] = { value };
+    world.E[entity] = new E(value);
   };
 }
 
@@ -53,10 +83,10 @@ export default (count) => {
   let world = new World();
 
   for (let i = 0; i < count; i++) {
-    instantiate(world, [A(0), B(1)]);
-    instantiate(world, [A(0), B(1), C(2)]);
-    instantiate(world, [A(0), B(1), C(2), D(3)]);
-    instantiate(world, [A(0), B(1), C(2), E(4)]);
+    instantiate(world, [a(0), b(1)]);
+    instantiate(world, [a(0), b(1), c(2)]);
+    instantiate(world, [a(0), b(1), c(2), d(3)]);
+    instantiate(world, [a(0), b(1), c(2), e(4)]);
   }
 
   const QUERY_AB = HAS_A | HAS_B;


### PR DESCRIPTION
When we use Goodluck in our games we store component data in object literals (typed via TS interfaces), but we do that due to the code size constaint of https://js13kgames.com. In canonical JS/TS we'd use classes to describe the data, and class instances to store it in component arrays.

The results are slightly better with this PR. I suspect it's due to the fact that the engine can make more assumptions about the shape of the objects stored in the component arrays.

@ooflorent, is this fair? If you think it is, I'll be happy to refactor the remaining test cases.